### PR TITLE
Fix image build

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -11,4 +11,4 @@ RUN npm ci
 
 COPY . /opt/app-root/src
 EXPOSE 443 8080
-CMD ["npm", "start"]
+CMD ["node", "--max-old-space-size=150", "./src/server.js"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM artifacts.developer.gov.bc.ca/docker-remote/node:14.20.1-alpine3.16
+FROM artifacts.developer.gov.bc.ca/docker-remote/node:18.16.0-alpine3.18
 
 RUN mkdir -p /logs
 RUN chmod 755 /logs

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM artifacts.developer.gov.bc.ca/docker-remote/node:14.20.1 as build-stage
+FROM artifacts.developer.gov.bc.ca/docker-remote/node:18.16.0-alpine3.18 as build-stage
 WORKDIR /frontend
 COPY package*.json ./
 RUN npm install


### PR DESCRIPTION
Images will not build due to package lock versions being up-to-date.  We need a recent version of node.  We also need to avoid using npm to run the backend.